### PR TITLE
Prevent page reload after project edit

### DIFF
--- a/pesticide_frontend/src/components/EditProjectForm.jsx
+++ b/pesticide_frontend/src/components/EditProjectForm.jsx
@@ -12,7 +12,6 @@ import Chip from "@material-ui/core/Chip";
 import { withRouter, Redirect } from "react-router-dom";
 import { connect } from "react-redux";
 import { Editor } from "@tinymce/tinymce-react";
-
 import axios from "axios";
 
 import ImageWithModal from "./ImageWithModal";
@@ -29,6 +28,10 @@ const EditProjectForm = (props) => {
   const [userList, setUserList] = React.useState([]);
   const [projectImage, setProjectImage] = React.useState(null);
   const [projectDescription, setProjectDescription] = React.useState("");
+  const [refresh, setRefresh] = React.useState({
+    refresh: false,
+    to: "",
+  });
 
   const handleFormChange = (event) => {
     const { name, value } = event.target;
@@ -145,9 +148,11 @@ const EditProjectForm = (props) => {
               });
           }
         }
-        setTimeout(() => {
-          window.location.href = "/projects";
-        }, 1000);
+        setRefresh({
+          refresh: true,
+          to: `/projects/${res.data.projectslug}`,
+        });
+        props.fetchData();
       })
       .catch((err) => {
         console.log(err);
@@ -395,6 +400,8 @@ const EditProjectForm = (props) => {
           </Grid>
         </form>
       </div>
+
+      {refresh && refresh.refresh && <Redirect to={refresh.to} />}
     </Container>
   );
 };

--- a/pesticide_frontend/src/components/EditProjectWithModal.jsx
+++ b/pesticide_frontend/src/components/EditProjectWithModal.jsx
@@ -5,9 +5,7 @@ import DialogContent from "@material-ui/core/DialogContent";
 import DialogTitle from "@material-ui/core/DialogTitle";
 import useMediaQuery from "@material-ui/core/useMediaQuery";
 import { useTheme } from "@material-ui/core/styles";
-import { makeStyles } from "@material-ui/core/styles";
 import CloseRoundedIcon from "@material-ui/icons/CloseRounded";
-import Slide from "@material-ui/core/Slide";
 import Grow from "@material-ui/core/Grow";
 import EditRoundedIcon from "@material-ui/icons/EditRounded";
 
@@ -15,43 +13,7 @@ import EditProjectForm from "./EditProjectForm";
 
 const isMobile = window.innerWidth < 850;
 
-const projectDetails = {
-  display: "flex",
-  flexDirection: isMobile ? "column" : "row",
-  justifyContent: isMobile ? "flex-start" : "space-between",
-  minWidth: "500px",
-};
-
-const projectDetailsLeftRight = {
-  display: "flex",
-  flexDirection: "row",
-  alignItems: "center",
-};
-
-const issueContainer = {
-  display: "flex",
-  flexDirection: "column",
-};
-
-const useStyles = makeStyles((theme) => ({
-  root: {
-    "& > *": {
-      margin: theme.spacing(1),
-    },
-  },
-  input: {
-    display: "none",
-  },
-}));
-
-const statusList = ["❌ Closed", "🔵 Open", "✔️ Fixed"];
-
-const Transition = React.forwardRef(function Transition(props, ref) {
-  return <Slide direction="up" ref={ref} {...props} />;
-});
-
 export default function EditProjectWithModal(props) {
-  const classes = useStyles();
   const [open, setOpen] = React.useState(false);
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
@@ -62,13 +24,6 @@ export default function EditProjectWithModal(props) {
 
   const handleClose = () => {
     setOpen(false);
-  };
-
-  const newProjectBtnStyle = {
-    margin: "10px",
-    border: "1.5px dashed #6e6e6eb5",
-    width: "auto",
-    borderRadius: "10px",
   };
 
   return (
@@ -108,7 +63,7 @@ export default function EditProjectWithModal(props) {
         </DialogTitle>
 
         <DialogContent style={{ padding: "5px 10px" }}>
-          <EditProjectForm projectID={props.projectID} />
+          <EditProjectForm projectID={props.projectID} fetchData={props.fetchData} />
         </DialogContent>
       </Dialog>
     </div>

--- a/pesticide_frontend/src/components/ProjectInfo.jsx
+++ b/pesticide_frontend/src/components/ProjectInfo.jsx
@@ -68,8 +68,7 @@ const ProjectInfo = (props) => {
       .catch((err) => console.log(err));
   }
 
-  React.useEffect(() => {
-    fetchCurrentUserInfo();
+  async function fetchProjectData() {
     axios
       .get(api_links.API_ROOT + `projects/${props.projectID}/`)
       .then((res) => {
@@ -89,6 +88,11 @@ const ProjectInfo = (props) => {
         setWiki(res.data.wiki);
       })
       .catch((err) => console.log(err));
+  }
+
+  React.useEffect(() => {
+    fetchCurrentUserInfo();
+    fetchProjectData();
   }, [props.projectID]);
 
   return (
@@ -221,6 +225,7 @@ const ProjectInfo = (props) => {
                       <EditProjectWithModal
                         projectID={props.projectID}
                         projectName={project.name}
+                        fetchData={fetchProjectData}
                       />
                       <Button
                         className="btn-filled-small btn-filled-small-error"
@@ -314,6 +319,7 @@ const ProjectInfo = (props) => {
                     projectID={props.projectID}
                     projectName={project.name}
                     large
+                    fetchData={fetchProjectData}
                   />
 
                   <Button


### PR DESCRIPTION
Prevent page reload after project edit. Now after editing project details, user is redirected to the new project page (if project name is changed) and new info is obtained to update the project info card.